### PR TITLE
Support Custom ClassLoader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ subprojects {
     apply plugin: 'maven'
 
     group = 'com.toasttab.fixy'
-    version = 2.2
+    version = 2.3
 
     sourceCompatibility = 1.7
 

--- a/fixy-core/src/main/java/fixy/CoreFixy.java
+++ b/fixy-core/src/main/java/fixy/CoreFixy.java
@@ -91,15 +91,10 @@ public final class CoreFixy extends CompactConstructor implements Fixy {
     @Override
     protected Class<?> getClassForName(String name) throws ClassNotFoundException {
         System.out.println("CoreFixy#getClassForName, name=" + name);
+        try {
+            return getClassForNameWithCustomClassLoader(name);
+        } catch (ClassNotFoundException ignored) { }
         if(!Strings.isNullOrEmpty(packageName)) {
-            if (classLoader != null) {
-                try {
-                    return Class.forName(packageName + "." + name, true, classLoader);
-                } catch (ClassNotFoundException ignored) { }
-                try {
-                    return Class.forName(name, true, classLoader);
-                } catch (ClassNotFoundException ignored) { }
-            }
             try {
                 return super.getClassForName(packageName + "." + name);
             } catch (ClassNotFoundException ignored) { }
@@ -112,6 +107,24 @@ public final class CoreFixy extends CompactConstructor implements Fixy {
         }
         try {
             return super.getClassForName("java.lang." + name);
+        } catch (ClassNotFoundException ignored) { }
+        throw exceptionToThrow;
+    }
+
+    private Class<?> getClassForNameWithCustomClassLoader(String name) throws ClassNotFoundException {
+        if (!Strings.isNullOrEmpty(packageName)) {
+            try {
+                return Class.forName(packageName + "." + name, true, classLoader);
+            } catch (ClassNotFoundException ignored) { }
+        }
+        ClassNotFoundException exceptionToThrow;
+        try {
+            return Class.forName(name, true, classLoader);
+        } catch (ClassNotFoundException e) {
+            exceptionToThrow = e;
+        }
+        try {
+            return Class.forName("java.lang." + name, true, classLoader);
         } catch (ClassNotFoundException ignored) { }
         throw exceptionToThrow;
     }

--- a/fixy-core/src/main/java/fixy/CoreFixy.java
+++ b/fixy-core/src/main/java/fixy/CoreFixy.java
@@ -64,6 +64,7 @@ public final class CoreFixy extends CompactConstructor implements Fixy {
     private final String defaultPackage;
     private final BeanAccess beanAccess;
     private String packageName;
+    private ClassLoader classLoader;
 
     public CoreFixy(Persister persister) {
         this(persister, "");
@@ -74,18 +75,31 @@ public final class CoreFixy extends CompactConstructor implements Fixy {
     }
 
     public CoreFixy(Persister persister, String defaultPackage, BeanAccess beanAccess) {
+        this(persister, defaultPackage, beanAccess, null);
+    }
+
+    public CoreFixy(Persister persister, String defaultPackage, BeanAccess beanAccess, ClassLoader classLoader) {
         this.yamlConstructors.put(new Tag("!import"), new ConstructImport(this));
         this.yamlConstructors.put(new Tag("!package"), new ConstructPackage(this));
         this.defaultPackage = defaultPackage;
         this.packageName = defaultPackage;
         this.persister = persister;
         this.beanAccess = beanAccess;
+        this.classLoader = classLoader;
     }
 
     @Override
     protected Class<?> getClassForName(String name) throws ClassNotFoundException {
         System.out.println("CoreFixy#getClassForName, name=" + name);
         if(!Strings.isNullOrEmpty(packageName)) {
+            if (classLoader != null) {
+                try {
+                    return Class.forName(packageName + "." + name, true, classLoader);
+                } catch (ClassNotFoundException ignored) { }
+                try {
+                    return Class.forName(name, true, classLoader);
+                } catch (ClassNotFoundException ignored) { }
+            }
             try {
                 return super.getClassForName(packageName + "." + name);
             } catch (ClassNotFoundException ignored) { }

--- a/fixy-jpa/src/main/java/fixy/JpaFixyBuilder.java
+++ b/fixy-jpa/src/main/java/fixy/JpaFixyBuilder.java
@@ -15,6 +15,7 @@ public class JpaFixyBuilder {
     private boolean mergeEntities;
     private String defaultPackage;
     private BeanAccess beanAccess = BeanAccess.DEFAULT;
+    private ClassLoader classLoader;
 
     /**
      * Creates the builder with a given JPA EntityManager.
@@ -58,15 +59,26 @@ public class JpaFixyBuilder {
     }
 
     /**
+     * Enables use of a custom class loader.
+     *
+     * @return the JpaFixyBuilder for further configuration
+     */
+    public JpaFixyBuilder withCustomClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+        return this;
+    }
+
+    /**
      * Builds the Fixy using the provided builder configuration.
      *
      * @return the configured Fixy
      */
     public Fixy build() {
         return new CoreFixy(
-            new JPAPersister(entityManager, mergeEntities),
-            defaultPackage,
-            beanAccess);
+                new JPAPersister(entityManager, mergeEntities),
+                defaultPackage,
+                beanAccess,
+                classLoader);
     }
 
 }


### PR DESCRIPTION
Adds a ClassLoader instance variable to CoreFixy and JpaFixyBuilder so that it can check in `getClassForName()` if a custom ClassLoader should be used before defaulting to the regular checks for a given class name.

Bootstrapping can now specify use of a custom classloader (like Play's classloader) like this:

```
Fixy fixtures = new JpaFixyBuilder(JPA.em())
    .withDefaultPackage("models")
    .withCustomClassLoader(Play.classloader)
    .build();
fixtures.load("master.yml");
```
